### PR TITLE
Fix broken link to CommandLineMoves.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ To get set up:
     ant crungui
     ```
 
-    For additional information about compiling MOVES, see [CommandLineMOVES.md](docs\CommandLineMOVES.md#compiling-moves).
+    For additional information about compiling MOVES, see [CommandLineMOVES.md](docs/CommandLineMOVES.md#compiling-moves).
 
 9. Hereafter to run MOVES, simply navigate to the MOVES directory and run:
 


### PR DESCRIPTION
The link to the CommandLineMoves.md document in the readme uses a `\` instead of a `/` so leads to a 404 page. This corrects that so the link works.