### PR TITLE
Fix swapped VSP/speed column values for OperatingMode 33 in test data

### DIFF
--- a/testdata/task118TestData.sql
+++ b/testdata/task118TestData.sql
@@ -10,9 +10,12 @@ INSERT IGNORE INTO EngineSize (engSizeID, engSizeName) VALUES (1, "displacement 
 
 
 --OperatingMode
+-- opMode 33: "VSP< 6; 50<=Speed" means VSPLower=NULL, VSPUpper=6, speedLower=50, speedUpper=NULL.
+-- The original values (6, 50, NULL, NULL) had VSPUpper and speedLower swapped, making opMode 33
+-- match "6 <= VSP < 50, any speed" — a broad catch-all that overlaps all narrow VSP modes.
 REPLACE INTO OperatingMode (opModeID, opModeName, VSPLower, VSPUpper, speedLower, 
 	speedUpper, brakeRate1Sec, brakeRate3Sec) VALUES (33, "Cruise/Acceleration; VSP< 6; 50<=Speed", 
-	6, 50, NULL, NULL, NULL, NULL);
+	NULL, 6, 50, NULL, NULL, NULL);
 REPLACE INTO OperatingMode (opModeID, opModeName, VSPLower, VSPUpper, speedLower, 
 	speedUpper, brakeRate1Sec, brakeRate3Sec) VALUES (36, "Cruise/Acceleration; 12 <= VSP; 50<=Speed", 
 	12, NULL, 50, NULL, NULL, NULL);

--- a/testdata/task118TestData.sql
+++ b/testdata/task118TestData.sql
@@ -10,9 +10,6 @@ INSERT IGNORE INTO EngineSize (engSizeID, engSizeName) VALUES (1, "displacement 
 
 
 --OperatingMode
--- opMode 33: "VSP< 6; 50<=Speed" means VSPLower=NULL, VSPUpper=6, speedLower=50, speedUpper=NULL.
--- The original values (6, 50, NULL, NULL) had VSPUpper and speedLower swapped, making opMode 33
--- match "6 <= VSP < 50, any speed" — a broad catch-all that overlaps all narrow VSP modes.
 REPLACE INTO OperatingMode (opModeID, opModeName, VSPLower, VSPUpper, speedLower, 
 	speedUpper, brakeRate1Sec, brakeRate3Sec) VALUES (33, "Cruise/Acceleration; VSP< 6; 50<=Speed", 
 	NULL, 6, 50, NULL, NULL, NULL);


### PR DESCRIPTION
Fixes #86.

The `REPLACE INTO OperatingMode` statement for opMode 33 in `testdata/task118TestData.sql` supplied column values that did not match the mode definition.

The columns are `(opModeID, opModeName, VSPLower, VSPUpper, speedLower, speedUpper, brakeRate1Sec, brakeRate3Sec)`. opMode 33 is named `"Cruise/Acceleration; VSP< 6; 50<=Speed"` but was inserted with `VSPLower=6, VSPUpper=50, speedLower=NULL, speedUpper=NULL`, contradicting the name (VSP < 6, Speed >= 50), the canonical MOVES opMode 33 bracket, and the adjacent opMode 36 row.

This changes the values to `VSPLower=NULL, VSPUpper=6, speedLower=50, speedUpper=NULL`:

```diff
-	6, 50, NULL, NULL, NULL, NULL);
+	NULL, 6, 50, NULL, NULL, NULL);
```

One-line test-data correction; no production code affected.