### PR TITLE
Make base rate floating-point summations deterministic in processDriveCycles

### DIFF
--- a/generators/baserategenerator/baserategenerator.go
+++ b/generators/baserategenerator/baserategenerator.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -2035,6 +2036,35 @@ func calculateDriveCycleOpModeDistribution(db *sql.DB, pDetail *SourceUseTypePhy
 	}
 }
 
+// combineDriveScheduleOpModeFractions adds the drive-schedule-weighted operating
+// mode fractions into dest. For each driveScheduleID present in scheduleFractions,
+// opModeFractions(driveScheduleID) supplies that schedule's per-opMode fractions,
+// each weighted by the schedule's fraction and summed into dest.
+//
+// The driveScheduleIDs are visited in ascending order so the floating-point
+// accumulation into dest[opModeID] is performed in a fixed, reproducible order.
+// Summing in Go's randomized map-iteration order would instead make the result
+// vary by roughly one unit in the last place from run to run, since
+// floating-point addition is not associative.
+func combineDriveScheduleOpModeFractions(dest, scheduleFractions map[int]float64,
+	opModeFractions func(driveScheduleID int) map[int]float64) {
+	driveScheduleIDs := make([]int, 0, len(scheduleFractions))
+	for driveScheduleID := range scheduleFractions {
+		driveScheduleIDs = append(driveScheduleIDs, driveScheduleID)
+	}
+	sort.Ints(driveScheduleIDs)
+	for _, driveScheduleID := range driveScheduleIDs {
+		driveScheduleFraction := scheduleFractions[driveScheduleID]
+		src := opModeFractions(driveScheduleID)
+		if src == nil {
+			continue
+		}
+		for opModeID, opModeFraction := range src {
+			dest[opModeID] = dest[opModeID] + driveScheduleFraction*opModeFraction
+		}
+	}
+}
+
 // Make operating mode distributions for drive cycles
 func processDriveCycles(romdForBaseRateQueue, romdForBaseRateByAgeQueue chan *romdBlock, sqlToWrite chan string) {
 	fmt.Println("processDriveCycles...")
@@ -2080,27 +2110,46 @@ func processDriveCycles(romdForBaseRateQueue, romdForBaseRateByAgeQueue chan *ro
 		}
 	}
 
-	// Combine the drive cycle operating mode distributions.
+	// Combine the drive cycle operating mode distributions. The accumulation is
+	// delegated to combineDriveScheduleOpModeFractions, which sums over
+	// driveScheduleID in ascending order so the floating-point result is
+	// identical across runs and platforms. Ranging over the scheduleFractions
+	// map directly would sum the terms in Go's randomized map-iteration order,
+	// making the result vary by roughly one ULP per run.
 	for dcbKey, dcbDetail := range driveCycleBracketedBins {
-		for driveScheduleID, driveScheduleFraction := range dcbDetail.scheduleFractions {
-			dsoKey := DriveScheduleOpModeDistributionKey{dcbKey.pDetail, driveScheduleID}
-			dsoDetail := driveScheduleOpModeDistributions[dsoKey]
-			if dsoDetail == nil {
-				continue
-			}
-			for opModeID, opModeFraction := range dsoDetail.opModeFractions {
-				dcbDetail.opModeFractions[opModeID] = dcbDetail.opModeFractions[opModeID] + driveScheduleFraction*opModeFraction
-			}
-		}
+		pDetail := dcbKey.pDetail
+		combineDriveScheduleOpModeFractions(dcbDetail.opModeFractions, dcbDetail.scheduleFractions,
+			func(driveScheduleID int) map[int]float64 {
+				dsoDetail := driveScheduleOpModeDistributions[DriveScheduleOpModeDistributionKey{pDetail, driveScheduleID}]
+				if dsoDetail == nil {
+					return nil
+				}
+				return dsoDetail.opModeFractions
+			})
 	}
 
 	opModesToIterate := make([]int, 0, 100)
 	opModesToIterate = append(opModesToIterate, 0)
 	opModesToIterate = append(opModesToIterate, 1)
 	opModesToIterate = append(opModesToIterate, 501)
-	for opModeID, _ := range operatingModes {
+	for opModeID := range operatingModes {
 		opModesToIterate = append(opModesToIterate, opModeID)
 	}
+	// Sort so the drivingIdleFraction accumulation below sums its terms in a
+	// fixed order across runs. opModeIDs 0, 1, and 501 are always present and
+	// operatingModes holds only 1 < id < 100, so no duplicates are introduced.
+	// Downstream enumeration requires only that opModeID form the outer grouping
+	// level, which any total order (including ascending) satisfies.
+	sort.Ints(opModesToIterate)
+
+	// avgSpeedBin keys in ascending order, used below so the drivingIdleFraction
+	// accumulation and the RatesOpModeDistribution enumeration iterate speed bins
+	// deterministically rather than in randomized map order.
+	avgSpeedBinIDsSorted := make([]int, 0, len(avgSpeedBin))
+	for avgSpeedBinID := range avgSpeedBin {
+		avgSpeedBinIDsSorted = append(avgSpeedBinIDsSorted, avgSpeedBinID)
+	}
+	sort.Ints(avgSpeedBinIDsSorted)
 
 	// Speedup access to bracketed bins
 	type dcbFastKey struct {
@@ -2117,6 +2166,16 @@ func processDriveCycles(romdForBaseRateQueue, romdForBaseRateByAgeQueue chan *ro
 		dk = dcbKey
 		v = append(v, &dk)
 		driveCycleBracketedBinsFast[k] = v
+	}
+	// Sort each bucket so the drivingIdleFraction accumulation that ranges over
+	// these slices sums its terms in a fixed order. Within a bucket roadTypeID
+	// and avgSpeedBinID are constant, so ordering by the physics detail's unique
+	// TempSourceTypeID gives a stable total order. The slices are otherwise built
+	// in randomized map-iteration order.
+	for _, v := range driveCycleBracketedBinsFast {
+		sort.Slice(v, func(i, j int) bool {
+			return v[i].pDetail.TempSourceTypeID < v[j].pDetail.TempSourceTypeID
+		})
 	}
 
 	// Store the idle fractions, needed for off-network idling (ONI).
@@ -2141,7 +2200,7 @@ func processDriveCycles(romdForBaseRateQueue, romdForBaseRateByAgeQueue chan *ro
 				idlingFraction := 0.0
 				notIdlingFraction := 0.0
 				for _, opModeID := range opModesToIterate {
-					for avgSpeedBinID, _ := range avgSpeedBin {
+					for _, avgSpeedBinID := range avgSpeedBinIDsSorted {
 						avgSpeedKey.sourceTypeID = sourceTypeID
 						avgSpeedKey.roadTypeID = roadTypeID
 						avgSpeedKey.hourDayID = hourDayID
@@ -2272,7 +2331,7 @@ func processDriveCycles(romdForBaseRateQueue, romdForBaseRateByAgeQueue chan *ro
 						if polProcessID != 11609 && opModeID == 501 {
 							continue
 						}
-						for avgSpeedBinID, _ := range avgSpeedBin {
+						for _, avgSpeedBinID := range avgSpeedBinIDsSorted {
 							avgSpeedKey.sourceTypeID = sourceTypeID // dcbKey.pDetail.RealSourceTypeID
 							avgSpeedKey.roadTypeID = roadTypeID     // dcbKey.roadTypeID
 							avgSpeedKey.hourDayID = hourDayID

--- a/generators/baserategenerator/summation_determinism_test.go
+++ b/generators/baserategenerator/summation_determinism_test.go
@@ -1,0 +1,177 @@
+/*
+Unit tests for floating-point summation-order determinism in the base rate generator.
+
+Background: Go randomizes map iteration order on every run and platform. Wherever the
+generator sums floating-point values while ranging over a map, floating-point
+non-associativity ((a+b)+c != a+(b+c)) makes the accumulated result vary from run to
+run in its least-significant bits. combineDriveScheduleOpModeFractions removes that
+variation for the drive-schedule-weighted operating mode fractions (which feed the
+RatesOpModeDistribution and base rate outputs) by summing over driveScheduleID in a
+fixed ascending order.
+
+These tests verify:
+ 1. The accumulated result is numerically correct.
+ 2. Repeated calls with the same inputs are bit-for-bit identical.
+ 3. The result is independent of the map iteration order that would otherwise be
+    seen by ranging over scheduleFractions directly (i.e. it matches a reference
+    computed in ascending driveScheduleID order), demonstrated with input values
+    chosen so that a different summation order produces a different float64.
+*/
+package baserategenerator
+
+import (
+	"math"
+	"sort"
+	"testing"
+)
+
+// referenceCombine sums the drive-schedule-weighted opMode fractions in ascending
+// driveScheduleID order. This is the canonical order the production helper must match.
+func referenceCombine(scheduleFractions map[int]float64,
+	perSchedule map[int]map[int]float64) map[int]float64 {
+	ids := make([]int, 0, len(scheduleFractions))
+	for id := range scheduleFractions {
+		ids = append(ids, id)
+	}
+	sort.Ints(ids)
+	dest := make(map[int]float64)
+	for _, id := range ids {
+		frac := scheduleFractions[id]
+		for opModeID, opModeFraction := range perSchedule[id] {
+			dest[opModeID] = dest[opModeID] + frac*opModeFraction
+		}
+	}
+	return dest
+}
+
+// callCombine drives the production helper against plain maps.
+func callCombine(scheduleFractions map[int]float64,
+	perSchedule map[int]map[int]float64) map[int]float64 {
+	dest := make(map[int]float64)
+	combineDriveScheduleOpModeFractions(dest, scheduleFractions,
+		func(driveScheduleID int) map[int]float64 {
+			return perSchedule[driveScheduleID]
+		})
+	return dest
+}
+
+// makeSummationCase builds a single opMode's contributions across many drive
+// schedules using values whose sum is order-sensitive in float64: a large term
+// interleaved with many tiny terms loses precision differently depending on the
+// order in which the tiny terms are added.
+func makeSummationCase() (map[int]float64, map[int]map[int]float64) {
+	const opModeID = 22
+	scheduleFractions := make(map[int]float64)
+	perSchedule := make(map[int]map[int]float64)
+
+	// One dominant term.
+	scheduleFractions[0] = 1.0
+	perSchedule[0] = map[int]float64{opModeID: 1e16}
+
+	// Many tiny terms; individually negligible against 1e16, but their placement
+	// relative to the big term changes the rounded result.
+	for id := 1; id <= 200; id++ {
+		scheduleFractions[id] = 1.0
+		perSchedule[id] = map[int]float64{opModeID: 1.0}
+	}
+	return scheduleFractions, perSchedule
+}
+
+// TestCombineIsCorrect checks a small, exactly-representable case.
+func TestCombineIsCorrect(t *testing.T) {
+	scheduleFractions := map[int]float64{
+		10: 0.5,
+		20: 0.25,
+		30: 0.25,
+	}
+	perSchedule := map[int]map[int]float64{
+		10: {1: 4, 2: 8},
+		20: {1: 4, 2: 8},
+		30: {2: 8},
+	}
+	got := callCombine(scheduleFractions, perSchedule)
+
+	// opMode 1: 0.5*4 + 0.25*4          = 3
+	// opMode 2: 0.5*8 + 0.25*8 + 0.25*8 = 8
+	want := map[int]float64{1: 3, 2: 8}
+	if len(got) != len(want) {
+		t.Fatalf("result size = %d, want %d (%v)", len(got), len(want), got)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("opMode %d = %v, want %v", k, got[k], v)
+		}
+	}
+}
+
+// TestCombineMatchesAscendingReference verifies the helper's result equals the
+// ascending-order reference for an order-sensitive input, and that the chosen
+// input really is order-sensitive (so the test would catch a regression to
+// map-order summation).
+func TestCombineMatchesAscendingReference(t *testing.T) {
+	scheduleFractions, perSchedule := makeSummationCase()
+
+	got := callCombine(scheduleFractions, perSchedule)
+	want := referenceCombine(scheduleFractions, perSchedule)
+
+	for opModeID, wantVal := range want {
+		if math.Float64bits(got[opModeID]) != math.Float64bits(wantVal) {
+			t.Errorf("opMode %d = %v, want %v (bit patterns differ)", opModeID, got[opModeID], wantVal)
+		}
+	}
+
+	// Sanity: confirm the input is order-sensitive so this test has teeth.
+	// Summing the big term last differs from summing it first in float64.
+	bigFirst := 1e16
+	for i := 0; i < 200; i++ {
+		bigFirst += 1.0
+	}
+	smallFirst := 0.0
+	for i := 0; i < 200; i++ {
+		smallFirst += 1.0
+	}
+	smallFirst += 1e16
+	if bigFirst == smallFirst {
+		t.Fatal("test input is not order-sensitive; it cannot detect map-order regressions")
+	}
+}
+
+// TestCombineIsRepeatable verifies repeated calls produce bit-identical results.
+func TestCombineIsRepeatable(t *testing.T) {
+	scheduleFractions, perSchedule := makeSummationCase()
+
+	first := callCombine(scheduleFractions, perSchedule)
+	for i := 0; i < 100; i++ {
+		got := callCombine(scheduleFractions, perSchedule)
+		if len(got) != len(first) {
+			t.Fatalf("iter %d: result size changed", i)
+		}
+		for opModeID, v := range first {
+			if math.Float64bits(got[opModeID]) != math.Float64bits(v) {
+				t.Errorf("iter %d: opMode %d = %v, first was %v (not reproducible)",
+					i, opModeID, got[opModeID], v)
+			}
+		}
+	}
+}
+
+// TestCombineSkipsMissingSchedules verifies that a driveScheduleID whose
+// opModeFractions lookup returns nil contributes nothing and does not panic.
+func TestCombineSkipsMissingSchedules(t *testing.T) {
+	scheduleFractions := map[int]float64{1: 0.5, 2: 0.5, 3: 0.5}
+	perSchedule := map[int]map[int]float64{
+		1: {7: 2},
+		3: {7: 2},
+		// id 2 intentionally absent -> lookup returns nil
+	}
+	dest := make(map[int]float64)
+	combineDriveScheduleOpModeFractions(dest, scheduleFractions,
+		func(driveScheduleID int) map[int]float64 {
+			return perSchedule[driveScheduleID] // nil for id 2
+		})
+
+	// opMode 7: 0.5*2 + 0.5*2 = 2 (schedule 2 skipped)
+	if dest[7] != 2 {
+		t.Errorf("opMode 7 = %v, want 2", dest[7])
+	}
+}


### PR DESCRIPTION
Fixes #90.

`processDriveCycles` summed floating-point values while ranging over maps, so randomized map order plus non-associative FP addition made `RatesOpModeDistribution`/base rate and `drivingIdleFraction` output vary by ~1 ULP run-to-run.

Canonicalize summation order at every affected site:
- Add `combineDriveScheduleOpModeFractions()` to sum drive-schedule-weighted opMode fractions over `driveScheduleID` in ascending order.
- Sort `opModesToIterate` ascending.
- Add `avgSpeedBinIDsSorted` and iterate it instead of the `avgSpeedBin` map (idle-fraction and enumeration loops).
- Sort each `driveCycleBracketedBinsFast` bucket by the unique `TempSourceTypeID`.

Numeric output changes by at most ~1 ULP versus current map-order behavior and becomes bit-reproducible on all platforms. Adds `summation_determinism_test.go` (correctness, repeatability, map-order independence, nil-schedule skip).