### PR TITLE
Use E10's ethanol volume in the altTHC speciation branches

### DIFF
--- a/calc/hcspeciation/hcspeciation.go
+++ b/calc/hcspeciation/hcspeciation.go
@@ -224,6 +224,11 @@ func calculate(inputBlocks chan *mwo.MWOBlock, outputBlocks chan *mwo.MWOBlock) 
 					continue
 				}
 				totalOxygenate := ff.MTBEVolume + ff.ETBEVolume + ff.TAMEVolume + ff.ETOHVolume
+				// The altTHC branches below deliberately use E10's factors even though the
+				// fuel is E70 or E85, so the oxygenate term takes E10's 10 percent ethanol by
+				// volume rather than this formulation's. See HCSpeciationCalculator.sql lines
+				// 763, 766, 862 and 865, and the @algorithm comments on those branches.
+				altTotalOxygenate := ff.MTBEVolume + ff.ETBEVolume + ff.TAMEVolume + 10
 				emissions := make(map[int]*mwo.MWOEmission)
 				ppid := 0
 
@@ -318,7 +323,7 @@ func calculate(inputBlocks chan *mwo.MWOBlock, outputBlocks chan *mwo.MWOBlock) 
 						if(mwo.NeededPolProcessIDs[ppid]) {
 							hcs := HCSpeciation[HCSpeciationKey{ppid,12,fb.Key.RegClassID,fb.Key.ModelYearID}]
 							if hcs != nil {
-								factor := hcs.speciationConstant + hcs.oxySpeciation * ff.VolToWtPercentOxy * totalOxygenate
+								factor := hcs.speciationConstant + hcs.oxySpeciation * ff.VolToWtPercentOxy * altTotalOxygenate
 								emissions[80] = mwo.NewEmissionScaled(emissions[10079],factor)
 							} else {
 								emissions[80] = mwo.NewEmissionScaled(e,0)
@@ -337,7 +342,7 @@ func calculate(inputBlocks chan *mwo.MWOBlock, outputBlocks chan *mwo.MWOBlock) 
 						if(mwo.NeededPolProcessIDs[ppid]) {
 							hcs := HCSpeciation[HCSpeciationKey{ppid,12,fb.Key.RegClassID,fb.Key.ModelYearID}]
 							if hcs != nil {
-								factor := hcs.speciationConstant + hcs.oxySpeciation * ff.VolToWtPercentOxy * totalOxygenate
+								factor := hcs.speciationConstant + hcs.oxySpeciation * ff.VolToWtPercentOxy * altTotalOxygenate
 								emissions[87] = mwo.NewEmissionScaled(emissions[10079],factor)
 							} else {
 								emissions[87] = mwo.NewEmissionScaled(e,0)

--- a/calc/hcspeciation/hcspeciation_test.go
+++ b/calc/hcspeciation/hcspeciation_test.go
@@ -1,0 +1,107 @@
+package hcspeciation
+
+import (
+	"math"
+	"testing"
+
+	"calc/mwo"
+)
+
+// The altTHC branch uses E10's factors even though the fuel is E70 or E85, and
+// HCSpeciationCalculator.sql spells the oxygenate term for it as
+// (MTBEVolume+ETBEVolume+TAMEVolume+10), with the literal 10 standing for E10's
+// ethanol volume. The @algorithm comments on the Go branches say the same.
+// These check the code agrees with them.
+func TestAltEthanolBranchUsesE10OxygenateVolume(t *testing.T) {
+	const (
+		fuelFormulationID = 9001
+		fuelSubTypeID     = 51 // E85
+		regClassID        = 30
+		modelYearID       = 2015
+		processID         = 1 // running exhaust
+		altNMHC           = 95.0
+
+		speciationConstant = 0.9
+		oxySpeciation      = 0.002
+		volToWtPercentOxy  = 0.35
+		ch4THCRatio        = 0.0
+	)
+
+	for _, tc := range []struct {
+		name       string
+		etohVolume float64
+	}{
+		// The oxygenate term must not depend on the formulation's own ethanol
+		// volume in this branch, so both rows expect the same factor.
+		{"E85 formulation", 79.0},
+		{"E10-like formulation, control", 10.0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mwo.FuelFormulations = map[int]*mwo.FuelFormulation{
+				fuelFormulationID: {
+					FuelFormulationID: fuelFormulationID,
+					FuelSubTypeID:     fuelSubTypeID,
+					ETOHVolume:        tc.etohVolume,
+					VolToWtPercentOxy: volToWtPercentOxy,
+					FuelTypeID:        5,
+				},
+			}
+			mwo.NeededPolProcessIDs = map[int]bool{
+				79*100 + processID: true,
+				80*100 + processID: true,
+			}
+			methaneTHCRatio = map[methaneTHCRatioKey]*methaneTHCRatioDetail{
+				{processID, 12, regClassID, modelYearID}: {CH4THCRatio: ch4THCRatio},
+			}
+			HCSpeciation = map[HCSpeciationKey]*HCSpeciationDetail{
+				{80*100 + processID, 12, regClassID, modelYearID}: {
+					speciationConstant: speciationConstant,
+					oxySpeciation:      oxySpeciation,
+				},
+			}
+
+			in := make(chan *mwo.MWOBlock, 1)
+			out := make(chan *mwo.MWOBlock, 1)
+			in <- &mwo.MWOBlock{FuelBlocks: []*mwo.FuelBlock{{
+				Key: mwo.MWOKey{
+					RegClassID:  regClassID,
+					FuelTypeID:  5,
+					ModelYearID: modelYearID,
+					PollutantID: 10001, // altTHC
+					ProcessID:   processID,
+				},
+				Emissions: []*mwo.MWOEmission{{
+					FuelSubTypeID:     fuelSubTypeID,
+					FuelFormulationID: fuelFormulationID,
+					EmissionQuant:     altNMHC,
+				}},
+			}}}
+			// calculate() receives without a comma-ok, so closing the channel
+			// would hand it a nil block. Run it as production does instead.
+			go calculate(in, out)
+
+			block := <-out
+			var nmog float64
+			var found bool
+			for _, fb := range block.FuelBlocks {
+				if fb.Key.PollutantID == 80 && fb.Key.ProcessID == processID {
+					for _, e := range fb.Emissions {
+						nmog = e.EmissionQuant
+						found = true
+					}
+				}
+			}
+			if !found {
+				t.Fatal("no NMOG (80) block was produced, so the branch under test never ran")
+			}
+
+			gotFactor := nmog / altNMHC
+			wantFactor := speciationConstant + oxySpeciation*volToWtPercentOxy*10
+
+			if math.Abs(gotFactor-wantFactor) > 1e-9 {
+				t.Errorf("oxygenate term used the formulation's ethanol volume: factor %.9f, want %.9f (per HCSpeciationCalculator.sql and the @algorithm comment)",
+					gotFactor, wantFactor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Go HC speciation calculator and the reference SQL disagree about one term in the altTHC branches, and the Go file's own `@algorithm` comment agrees with the SQL rather than with the code beneath it.

`database/HCSpeciationCalculator.sql` uses the literal 10 for the alt NMOG and VOC branches (lines 763, 766, 862, 865), and says why at 748-750:

```
-- @algorithm Calculate NMOG from altNMHC (10079) that originates from altTHC (10001).
-- Use E10's factors even though the fuel is Ethanol.
-- NMOG = altNMHC*(speciationConstant + oxySpeciation* volToWtPercentOxy*(MTBEVolume+ETBEVolume+TAMEVolume+10)).
```

`calc/hcspeciation/hcspeciation.go` carries that same comment, `+10` included, at lines 309-311 and 328-330. The code computes one value at line 226 and reuses it in all four branches:

```go
totalOxygenate := ff.MTBEVolume + ff.ETBEVolume + ff.TAMEVolume + ff.ETOHVolume
```

That matches the SQL in the two main branches, which also use `ETOHVolume` (lines 726-732, 825-831). In the two alt branches the fuel is E70 or E85 by construction, so `ff.ETOHVolume` is roughly 68 to 85 where the specification says 10.

What makes this look like a copy-paste residual rather than an intended divergence is that everything else about the alt branch is translated faithfully. Both `HCSpeciation` lookups hardcode the E10 subtype (`HCSpeciationKey{ppid,12,...}`, matching `hcs.fuelSubtypeID=12` in the SQL), the methane ratio uses subtype 12 with the comment `/*12==E10 fuelsubtypeID*/`, `VolToWtPercentOxy` comes from the actual formulation exactly as the SQL does, and the branch condition `FuelSubTypeID == 50 || 51 || 52` matches what `HCSpeciationCalculator.java:315` substitutes for `##e85E70FuelSubtypeIDs##`. Only the ethanol volume differs.

Verification: `calc/hcspeciation/hcspeciation_test.go` drives the real `calculate` function over its production input and output channels with an E85 formulation and an altTHC (10001) input block, then divides the NMOG it emits by the input to recover the factor. On `master`:

```
--- FAIL: TestAltEthanolBranchUsesE10OxygenateVolume/E85_formulation
    oxygenate term used the formulation's ethanol volume: factor 0.955300000, want 0.907000000
--- PASS: TestAltEthanolBranchUsesE10OxygenateVolume/E10-like_formulation,_control
```

The second row is the control: with `ETOHVolume` at 10 the two formulas coincide exactly, so the harness is comparing what it claims to and the divergence is specifically this term. Both pass with the change.

Two things I want to be straight about. First, I am not in a position to say which of the two implementations you consider authoritative; what I can show is that the code contradicts both the SQL and its own comment, and this change makes them agree. If the SQL is the one that is stale, the fix belongs there instead and I am happy to redo it that way. Second, on magnitude: the oxygenate contribution is inflated by the ratio of the formulation's ethanol volume to 10, but how far that moves final NMOG and VOC depends on the real `oxySpeciation` and `speciationConstant` values, which live in the default database rather than this repository. The 0.9553 against 0.9070 above comes from illustrative coefficients, so please do not read it as the production error.

Unrelated, noticed while writing the test and not touched here: `calculate` receives with `b := <- inputBlocks` and no comma-ok, so if the input channel is ever closed it takes a nil block and panics on `b.FuelBlocks`, despite the doc comment saying it processes until the channel is closed and then quits.
